### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM fedora
+
+RUN dnf -y update && \
+    dnf -y install graphviz python3-configargparse && \
+    dnf clean all
+
+COPY orgviz.py /usr/local/bin/orgviz
+
+ENTRYPOINT ["/usr/local/bin/orgviz"]


### PR DESCRIPTION
This requires #3 to work in a sensible way.

To build the container:

    podman build . -t orgviz

To execute the example:

    podman run -v .:/mnt/:Z localhost/orgviz --input /mnt/examples/ExampleCompany.org -P --output /mnt

It would be a good idea to push this image in a registry, such as quay.io, but usually is better if the repo owner does it so that the name stays the same as the repo.

This would make deploying easier and 100% cross-OS.

ps: obviously the same commands should also work for Docker